### PR TITLE
Update entry for Toronto subway

### DIFF
--- a/data/transit/route/subway.json
+++ b/data/transit/route/subway.json
@@ -864,21 +864,6 @@
       }
     },
     {
-      "displayName": "Toronto subway",
-      "id": "torontosubway-0ff3e0",
-      "locationSet": {
-        "include": ["ca-on.geojson"]
-      },
-      "tags": {
-        "network": "Toronto subway",
-        "network:wikidata": "Q20379",
-        "operator": "Toronto Transit Commission",
-        "operator:short": "TTC",
-        "operator:wikidata": "Q17978",
-        "route": "subway"
-      }
-    },
-    {
       "displayName": "TRAM Metropolità d'Alacant",
       "id": "trammetropolitadalacant-120cc8",
       "locationSet": {
@@ -907,6 +892,26 @@
       "tags": {
         "network": "Translink",
         "network:wikidata": "Q1142140",
+        "route": "subway"
+      }
+    },
+    {
+      "displayName": "TTC",
+      "locationSet": {
+        "include": ["ca-on.geojson"]
+      },
+      "matchNames": [
+        "toronto subway",
+        "ttc subway",
+      ],
+      "tags": {
+        "network": "TTC",
+        "network:metro": "Toronto subway",
+        "network:metro:wikidata": "Q20379",
+        "network:wikidata": "Q6612865"
+        "operator": "Toronto Transit Commission",
+        "operator:short": "TTC",
+        "operator:wikidata": "Q17978",
         "route": "subway"
       }
     },


### PR DESCRIPTION
This updates the tag preset for Toronto subway, moving "Toronto subway" to network:metro and its associated Wikidata to network:metro:wikidata, making TTC the network value (in line with other transit modes under the Toronto Transit Commission such as its buses and streetcars/trams which have been using network=TTC for long). This follows up a similar change completed for Calgary Transit's CTrain light rail transit (LRT) network, which moves the system branding under network:metro.