### PR TITLE
California Pizza Kitchen outside U.S.

### DIFF
--- a/data/brands/amenity/restaurant.json
+++ b/data/brands/amenity/restaurant.json
@@ -1420,7 +1420,7 @@
     {
       "displayName": "California Pizza Kitchen",
       "id": "californiapizzakitchen-96af40",
-      "locationSet": {"include": ["us"]},
+      "locationSet": {"include": ["ca", "ph", "us"]},
       "tags": {
         "amenity": "restaurant",
         "brand": "California Pizza Kitchen",


### PR DESCRIPTION
add Canada and the Philippines for California Pizza Kitchen (some locations in those countries)